### PR TITLE
Minor changes to APIs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,10 @@ if(LLVM_MLBRIDGE)
   target_include_directories(LLVMMLBridge SYSTEM PUBLIC ${Protobuf_INCLUDE_DIRS} ${TENSORFLOW_AOT_PATH}/include)
   target_include_directories(LLVMMLBridge PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
   install(TARGETS LLVMMLBridge DESTINATION lib)
+  add_custom_command(TARGET LLVMMLBridge
+    POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/CompilerInterface ${CMAKE_CURRENT_BINARY_DIR}/CompilerInterface
+  )
 
 else()
   llvm_map_components_to_libnames(llvm_libs support core irreader analysis TransformUtils)

--- a/SerDes/bitstreamSerDes.cpp
+++ b/SerDes/bitstreamSerDes.cpp
@@ -26,28 +26,28 @@
 #define DEBUG_TYPE "bitstream-serdes"
 
 namespace MLBridge {
-void BitstreamSerDes::setFeature(const std::string &name, const int &value) {
+void BitstreamSerDes::setFeature(const std::string &name, const int value) {
   auto *valuePtr = new int(value);
   featuresint[name] = valuePtr;
   tensorSpecs.push_back(TensorSpec::createSpec<int>(name, {1}));
   rawData.push_back(valuePtr);
 }
 
-void BitstreamSerDes::setFeature(const std::string &name, const long &value) {
+void BitstreamSerDes::setFeature(const std::string &name, const long value) {
   auto *valuePtr = new long(value);
   featureslong[name] = valuePtr;
   tensorSpecs.push_back(TensorSpec::createSpec<long>(name, {1}));
   rawData.push_back(valuePtr);
 }
 
-void BitstreamSerDes::setFeature(const std::string &name, const float &value) {
+void BitstreamSerDes::setFeature(const std::string &name, const float value) {
   auto *valuePtr = new float(value);
   featuresfloat[name] = valuePtr;
   tensorSpecs.push_back(TensorSpec::createSpec<float>(name, {1}));
   rawData.push_back(valuePtr);
 }
 
-void BitstreamSerDes::setFeature(const std::string &name, const double &value) {
+void BitstreamSerDes::setFeature(const std::string &name, const double value) {
   auto *valuePtr = new double(value);
   featuresdouble[name] = valuePtr;
   tensorSpecs.push_back(TensorSpec::createSpec<double>(name, {1}));
@@ -55,7 +55,7 @@ void BitstreamSerDes::setFeature(const std::string &name, const double &value) {
 }
 
 void BitstreamSerDes::setFeature(const std::string &name,
-                                 const std::string &value) {
+                                 const std::string value) {
   auto *valuePtr = new std::string(value);
   featuresstring[name] = valuePtr;
   long size = value.length();
@@ -63,7 +63,7 @@ void BitstreamSerDes::setFeature(const std::string &name,
   rawData.push_back((void *)valuePtr->c_str());
 }
 
-void BitstreamSerDes::setFeature(const std::string &name, const bool &value) {
+void BitstreamSerDes::setFeature(const std::string &name, const bool value) {
   auto *valuePtr = new bool(value);
   featuresbool[name] = valuePtr;
   tensorSpecs.push_back(TensorSpec::createSpec<uint8_t>(name, {1}));

--- a/SerDes/protobufSerDes.cpp
+++ b/SerDes/protobufSerDes.cpp
@@ -25,37 +25,37 @@
 
 namespace MLBridge {
 inline void ProtobufSerDes::setFeature(const std::string &name,
-                                       const int &value) {
+                                       const int value) {
   Request->GetReflection()->SetInt32(
       Request, Request->GetDescriptor()->FindFieldByName(name), value);
 }
 
 inline void ProtobufSerDes::setFeature(const std::string &name,
-                                       const long &value) {
+                                       const long value) {
   Request->GetReflection()->SetInt64(
       Request, Request->GetDescriptor()->FindFieldByName(name), value);
 }
 
 inline void ProtobufSerDes::setFeature(const std::string &name,
-                                       const float &value) {
+                                       const float value) {
   Request->GetReflection()->SetFloat(
       Request, Request->GetDescriptor()->FindFieldByName(name), value);
 }
 
 inline void ProtobufSerDes::setFeature(const std::string &name,
-                                       const double &value) {
+                                       const double value) {
   Request->GetReflection()->SetDouble(
       Request, Request->GetDescriptor()->FindFieldByName(name), value);
 }
 
 inline void ProtobufSerDes::setFeature(const std::string &name,
-                                       const std::string &value) {
+                                       const std::string value) {
   Request->GetReflection()->SetString(
       Request, Request->GetDescriptor()->FindFieldByName(name), value);
 }
 
 inline void ProtobufSerDes::setFeature(const std::string &name,
-                                       const bool &value) {
+                                       const bool value) {
   Request->GetReflection()->SetBool(
       Request, Request->GetDescriptor()->FindFieldByName(name), value);
 }

--- a/SerDes/tensorflowSerDes.cpp
+++ b/SerDes/tensorflowSerDes.cpp
@@ -17,9 +17,9 @@
 
 // #define EXCEPT_LONG(M) M(int) M(float) M(double) M(std::string) M(bool)
 namespace MLBridge {
-#define SET_FEATURE(TYPE)                                                      \
+#define SET_FEATURE(TYPE, _)                                                   \
   void TensorflowSerDes::setFeature(const std::string &Name,                   \
-                                    const TYPE &Value) {                       \
+                                    const TYPE Value) {                        \
     std::string prefix = "feed_";                                              \
     const int Index = CompiledModel->LookupArgIndex(prefix + Name);            \
     if (Index >= 0)                                                            \

--- a/include/MLModelRunner/MLModelRunner.h
+++ b/include/MLModelRunner/MLModelRunner.h
@@ -92,9 +92,17 @@ public:
   /// The features are passed as a list of key-value pairs.
   /// The key is the name of the feature and the value is the value of the
   /// feature. The value can be a scalar or a vector.
-  template <typename T, typename... Types>
-  void populateFeatures(std::pair<std::string, T> &var1,
-                        std::pair<std::string, Types> &...var2) {
+
+  template <typename U, typename T, typename... Types>
+  void populateFeatures(const std::pair<U, T> &var1,
+                        const std::pair<U, Types> &...var2) {
+    SerDes->setFeature(var1.first, var1.second);
+    populateFeatures(var2...);
+  }
+
+  template <typename U, typename T, typename... Types>
+  void populateFeatures(const std::pair<U, T> &&var1,
+                        const std::pair<U, Types> &&...var2) {
     SerDes->setFeature(var1.first, var1.second);
     populateFeatures(var2...);
   }

--- a/include/SerDes/baseSerDes.h
+++ b/include/SerDes/baseSerDes.h
@@ -21,21 +21,21 @@
 #include "MLModelRunner/Utils/Debug.h"
 #include "google/protobuf/extension_set.h"
 #include "google/protobuf/message.h"
+#include "llvm/Support/raw_ostream.h"
 
 #include <cassert>
 #include <map>
 #include <string>
 #include <vector>
 
-using namespace std;
-
+// TYPE, NAME
 #define SUPPORTED_TYPES(M)                                                     \
-  M(int)                                                                       \
-  M(long)                                                                      \
-  M(float)                                                                     \
-  M(double)                                                                    \
-  M(string)                                                                    \
-  M(bool)
+  M(int, int)                                                                  \
+  M(long, long)                                                                \
+  M(float, float)                                                              \
+  M(double, double)                                                            \
+  M(std::string, string)                                                       \
+  M(bool, bool)
 
 namespace MLBridge {
 /// This is the base class for SerDes. It defines the interface for the
@@ -51,8 +51,8 @@ public:
   /// setFeature() is used to set the features of the data structure used for
   /// communication. The features are set as key-value pairs. The key is a
   /// string and the value can be any of the supported types.
-#define SET_FEATURE(TYPE)                                                      \
-  virtual void setFeature(const std::string &, const TYPE &) = 0;              \
+#define SET_FEATURE(TYPE, _)                                                   \
+  virtual void setFeature(const std::string &, const TYPE) = 0;                \
   virtual void setFeature(const std::string &, const std::vector<TYPE> &){};
   SUPPORTED_TYPES(SET_FEATURE)
 #undef SET_FEATURE

--- a/include/SerDes/bitstreamSerDes.h
+++ b/include/SerDes/bitstreamSerDes.h
@@ -33,14 +33,14 @@ public:
     tensorSpecs = std::vector<TensorSpec>();
     rawData = std::vector<const void *>();
 
-#define TEMPORARY_STORAGE_INIT(TYPE)                                           \
-  features##TYPE = {};                                                         \
-  featuresVector##TYPE = {};
+#define TEMPORARY_STORAGE_INIT(TYPE, NAME)                                     \
+  features##NAME = {};                                                         \
+  featuresVector##NAME = {};
     SUPPORTED_TYPES(TEMPORARY_STORAGE_INIT)
 #undef TEMPORARY_STORAGE_INIT
   };
-#define SET_FEATURE(TYPE)                                                      \
-  void setFeature(const std::string &, const TYPE &) override;                 \
+#define SET_FEATURE(TYPE, _)                                                   \
+  void setFeature(const std::string &, const TYPE) override;                   \
   void setFeature(const std::string &, const std::vector<TYPE> &) override;
   SUPPORTED_TYPES(SET_FEATURE)
 #undef SET_FEATURE
@@ -52,17 +52,17 @@ public:
     tensorSpecs = std::vector<TensorSpec>();
     rawData = std::vector<const void *>();
 
-#define TEMPORARY_STORAGE_CLEAN(TYPE)                                          \
-  for (auto &it : features##TYPE) {                                            \
+#define TEMPORARY_STORAGE_CLEAN(TYPE, NAME)                                    \
+  for (auto &it : features##NAME) {                                            \
     delete it.second;                                                          \
   }                                                                            \
-  features##TYPE.clear();                                                      \
-  features##TYPE = {};                                                         \
-  for (auto &it : featuresVector##TYPE) {                                      \
+  features##NAME.clear();                                                      \
+  features##NAME = {};                                                         \
+  for (auto &it : featuresVector##NAME) {                                      \
     delete it.second;                                                          \
   }                                                                            \
-  featuresVector##TYPE.clear();                                                \
-  featuresVector##TYPE = {};
+  featuresVector##NAME.clear();                                                \
+  featuresVector##NAME = {};
     SUPPORTED_TYPES(TEMPORARY_STORAGE_CLEAN)
 #undef TEMPORARY_STORAGE_CLEAN
   }
@@ -73,9 +73,9 @@ private:
   std::vector<const void *> rawData;
   std::string Buffer;
 
-#define TEMPORARY_STORAGE_DEF(TYPE)                                            \
-  std::map<std::string, TYPE *> features##TYPE;                                \
-  std::map<std::string, std::vector<TYPE> *> featuresVector##TYPE;
+#define TEMPORARY_STORAGE_DEF(TYPE, NAME)                                      \
+  std::map<std::string, TYPE *> features##NAME;                                \
+  std::map<std::string, std::vector<TYPE> *> featuresVector##NAME;
   SUPPORTED_TYPES(TEMPORARY_STORAGE_DEF)
 #undef TEMPORARY_STORAGE_DEF
 };

--- a/include/SerDes/jsonSerDes.h
+++ b/include/SerDes/jsonSerDes.h
@@ -29,8 +29,8 @@ public:
     return S->getKind() == BaseSerDes::Kind::Json;
   }
 
-#define SET_FEATURE(TYPE)                                                      \
-  void setFeature(const std::string &name, const TYPE &value) override {       \
+#define SET_FEATURE(TYPE, _)                                                   \
+  void setFeature(const std::string &name, const TYPE value) override {        \
     J[name] = value;                                                           \
   }                                                                            \
   void setFeature(const std::string &name, const std::vector<TYPE> &value)     \

--- a/include/SerDes/protobufSerDes.h
+++ b/include/SerDes/protobufSerDes.h
@@ -38,8 +38,8 @@ public:
 
   void *getResponse() override { return Response; }
 
-#define SET_FEATURE(TYPE)                                                      \
-  virtual void setFeature(const std::string &, const TYPE &) override;         \
+#define SET_FEATURE(TYPE, _)                                                   \
+  virtual void setFeature(const std::string &, const TYPE) override;           \
   virtual void setFeature(const std::string &, const std::vector<TYPE> &)      \
       override;
   SUPPORTED_TYPES(SET_FEATURE)

--- a/include/SerDes/tensorflowSerDes.h
+++ b/include/SerDes/tensorflowSerDes.h
@@ -27,8 +27,8 @@ public:
     return S->getKind() == BaseSerDes::Kind::Tensorflow;
   }
 
-#define SET_FEATURE(TYPE)                                                      \
-  void setFeature(const std::string &, const TYPE &) override;                 \
+#define SET_FEATURE(TYPE, _)                                                   \
+  void setFeature(const std::string &, const TYPE) override;                   \
   void setFeature(const std::string &, const std::vector<TYPE> &) override;
   SUPPORTED_TYPES(SET_FEATURE)
 #undef SET_FEATURE


### PR DESCRIPTION
1. Changed to pass by value instead of reference for ```setFeature``` primitive types
2. Added ```populateFeatures``` function which accepts rvalues
3. Workaround to remove ```using namespace std;``` from baseSerDes.h